### PR TITLE
🐛 fix unavailable `typing` imports on `python<3.11` (codemod)

### DIFF
--- a/src/numpy-stubs/__config__.pyi
+++ b/src/numpy-stubs/__config__.pyi
@@ -1,6 +1,7 @@
 from enum import Enum
 from types import ModuleType
-from typing import Final, Literal as L, NotRequired, TypedDict, overload, type_check_only
+from typing import Final, Literal as L, TypedDict, overload, type_check_only
+from typing_extensions import NotRequired
 
 _CompilerConfigDictValue = TypedDict(
     "_CompilerConfigDictValue",

--- a/src/numpy-stubs/_array_api_info.pyi
+++ b/src/numpy-stubs/_array_api_info.pyi
@@ -1,5 +1,5 @@
-from typing import ClassVar, Literal, TypeAlias, TypeVar, TypedDict, final, overload, type_check_only
-from typing_extensions import Never
+from typing import ClassVar, Literal, TypeAlias, TypedDict, final, overload, type_check_only
+from typing_extensions import Never, TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/_core/_asarray.pyi
+++ b/src/numpy-stubs/_core/_asarray.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
-from typing import Any, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
 
 from numpy._typing import DTypeLike, NDArray, _SupportsArrayFunc
 

--- a/src/numpy-stubs/_core/defchararray.pyi
+++ b/src/numpy-stubs/_core/defchararray.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, SupportsIndex, SupportsInt, TypeAlias, TypeVar, overload
+from typing import Any, Literal as L, SupportsIndex, SupportsInt, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._core.multiarray import compare_chararrays

--- a/src/numpy-stubs/_core/einsumfunc.pyi
+++ b/src/numpy-stubs/_core/einsumfunc.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, Literal, TypeAlias, TypeVar, overload
+from typing import Any, Literal, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import (

--- a/src/numpy-stubs/_core/fromnumeric.pyi
+++ b/src/numpy-stubs/_core/fromnumeric.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, Literal, NoReturn, Protocol, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
-from typing_extensions import Never, deprecated
+from typing import Any, Literal, NoReturn, Protocol, SupportsIndex, TypeAlias, overload, type_check_only
+from typing_extensions import Never, TypeVar, deprecated
 
 import numpy as np
 from numpy._typing import (

--- a/src/numpy-stubs/_core/function_base.pyi
+++ b/src/numpy-stubs/_core/function_base.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, SupportsIndex, TypeVar, overload
+from typing import Any, Literal as L, SupportsIndex, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import DTypeLike, NDArray, _ArrayLikeComplex_co, _ArrayLikeFloat_co, _DTypeLike

--- a/src/numpy-stubs/_core/multiarray.pyi
+++ b/src/numpy-stubs/_core/multiarray.pyi
@@ -9,13 +9,12 @@ from typing import (
     Protocol,
     SupportsIndex,
     TypeAlias,
-    TypeVar,
     TypedDict,
     final,
     overload,
     type_check_only,
 )
-from typing_extensions import CapsuleType, Unpack
+from typing_extensions import CapsuleType, TypeVar, Unpack
 
 import numpy as np
 from numpy import (  # noqa: ICN003

--- a/src/numpy-stubs/_core/numeric.pyi
+++ b/src/numpy-stubs/_core/numeric.pyi
@@ -7,10 +7,9 @@ from typing import (
     SupportsAbs,
     SupportsIndex,
     TypeAlias,
-    TypeVar,
     overload,
 )
-from typing_extensions import TypeIs, Unpack
+from typing_extensions import TypeIs, TypeVar, Unpack
 
 import numpy as np
 from numpy import (  # noqa: ICN003

--- a/src/numpy-stubs/_core/records.pyi
+++ b/src/numpy-stubs/_core/records.pyi
@@ -1,7 +1,8 @@
 from _typeshed import Incomplete, StrOrBytesPath
 from collections.abc import Iterable, Sequence
 from types import EllipsisType
-from typing import Any, Literal, Protocol, SupportsIndex, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, Literal, Protocol, SupportsIndex, TypeAlias, overload, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import (

--- a/src/numpy-stubs/_core/shape_base.pyi
+++ b/src/numpy-stubs/_core/shape_base.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, SupportsIndex, TypeVar, overload
+from typing import Any, SupportsIndex, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import ArrayLike, DTypeLike, NDArray, _ArrayLike, _DTypeLike

--- a/src/numpy-stubs/_typing/_array_like.pyi
+++ b/src/numpy-stubs/_typing/_array_like.pyi
@@ -1,6 +1,7 @@
 import sys
 from collections.abc import Callable, Collection, Sequence
-from typing import Any, Never as _UnknownType, Protocol, TypeAlias, TypeVar, runtime_checkable
+from typing import Any, Never as _UnknownType, Protocol, TypeAlias, runtime_checkable
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy.dtypes import StringDType

--- a/src/numpy-stubs/_typing/_callable.pyi
+++ b/src/numpy-stubs/_typing/_callable.pyi
@@ -3,11 +3,11 @@ from typing import (
     NoReturn,
     Protocol,
     TypeAlias,
-    TypeVar,
     final,
     overload,
     type_check_only,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/_typing/_dtype_like.pyi
+++ b/src/numpy-stubs/_typing/_dtype_like.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, Protocol, TypeAlias, TypeVar, TypedDict, runtime_checkable
+from typing import Any, Protocol, TypeAlias, TypedDict, runtime_checkable
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/_typing/_nested_sequence.pyi
+++ b/src/numpy-stubs/_typing/_nested_sequence.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
-from typing import Any, Protocol, TypeVar
+from typing import Any, Protocol
+from typing_extensions import TypeVar
 
 __all__ = ["_NestedSequence"]
 

--- a/src/numpy-stubs/_typing/_ufunc.pyi
+++ b/src/numpy-stubs/_typing/_ufunc.pyi
@@ -2,17 +2,15 @@ from typing import (
     Any,
     Generic,
     Literal,
-    LiteralString,
     NoReturn,
     Protocol,
     SupportsIndex,
     TypeAlias,
-    TypeVar,
     TypedDict,
     overload,
     type_check_only,
 )
-from typing_extensions import Unpack
+from typing_extensions import LiteralString, TypeVar, Unpack
 
 import numpy as np
 import numpy.typing as npt

--- a/src/numpy-stubs/ctypeslib/_ctypeslib.pyi
+++ b/src/numpy-stubs/ctypeslib/_ctypeslib.pyi
@@ -1,7 +1,8 @@
 import ctypes as ct
 from _typeshed import StrOrBytesPath
 from collections.abc import Iterable, Sequence
-from typing import Any, ClassVar, Generic, Literal as L, TypeAlias, TypeVar, overload
+from typing import Any, ClassVar, Generic, Literal as L, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._core._internal import _ctypes

--- a/src/numpy-stubs/dtypes.pyi
+++ b/src/numpy-stubs/dtypes.pyi
@@ -3,14 +3,12 @@ from typing import (
     Final,
     Generic,
     Literal as L,
-    LiteralString,
     NoReturn,
-    Self,
     TypeAlias,
     final,
     type_check_only,
 )
-from typing_extensions import TypeVar
+from typing_extensions import LiteralString, Self, TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/fft/_helper.pyi
+++ b/src/numpy-stubs/fft/_helper.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, TypeVar, overload
+from typing import Any, Literal as L, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import ArrayLike, NDArray, _ArrayLike, _ArrayLikeComplex_co, _ArrayLikeFloat_co, _ShapeLike

--- a/src/numpy-stubs/lib/_arraypad_impl.pyi
+++ b/src/numpy-stubs/lib/_arraypad_impl.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
-from typing import Any, Literal as L, Protocol, TypeAlias, TypeVar, overload, type_check_only
+from typing import Any, Literal as L, Protocol, TypeAlias, overload, type_check_only
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import ArrayLike, NDArray, _ArrayLike, _ArrayLikeInt

--- a/src/numpy-stubs/lib/_arraysetops_impl.pyi
+++ b/src/numpy-stubs/lib/_arraysetops_impl.pyi
@@ -1,5 +1,5 @@
-from typing import Any, Generic, Literal as L, NamedTuple, SupportsIndex, TypeVar, overload
-from typing_extensions import deprecated
+from typing import Any, Generic, Literal as L, NamedTuple, SupportsIndex, overload
+from typing_extensions import TypeVar, deprecated
 
 import numpy as np
 from numpy._typing import (

--- a/src/numpy-stubs/lib/_arrayterator_impl.pyi
+++ b/src/numpy-stubs/lib/_arrayterator_impl.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Generator, Iterator
 from types import EllipsisType
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/lib/_function_base_impl.pyi
+++ b/src/numpy-stubs/lib/_function_base_impl.pyi
@@ -3,16 +3,14 @@ from typing import (
     Any,
     Concatenate,
     Literal as L,
-    ParamSpec,
     Protocol,
     SupportsIndex,
     SupportsInt,
     TypeAlias,
-    TypeVar,
     overload,
     type_check_only,
 )
-from typing_extensions import TypeIs, deprecated
+from typing_extensions import ParamSpec, TypeIs, TypeVar, deprecated
 
 import numpy as np
 from numpy import vectorize  # noqa: ICN003

--- a/src/numpy-stubs/lib/_npyio_impl.pyi
+++ b/src/numpy-stubs/lib/_npyio_impl.pyi
@@ -3,8 +3,8 @@ import zipfile
 from _typeshed import StrOrBytesPath, StrPath, SupportsKeysAndGetItem, SupportsRead, SupportsWrite
 from collections.abc import Callable, Collection, Iterable, Iterator, Mapping, Sequence
 from re import Pattern
-from typing import IO, Any, Generic, Literal as L, Protocol, TypeVar, overload, type_check_only
-from typing_extensions import Self, deprecated
+from typing import IO, Any, Generic, Literal as L, Protocol, overload, type_check_only
+from typing_extensions import Self, TypeVar, deprecated
 
 import numpy as np
 from numpy._core.multiarray import packbits, unpackbits

--- a/src/numpy-stubs/lib/_polynomial_impl.pyi
+++ b/src/numpy-stubs/lib/_polynomial_impl.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, NoReturn, SupportsIndex, SupportsInt, TypeAlias, TypeVar, overload
+from typing import Any, Literal as L, NoReturn, SupportsIndex, SupportsInt, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy import poly1d  # noqa: ICN003

--- a/src/numpy-stubs/lib/_shape_base_impl.pyi
+++ b/src/numpy-stubs/lib/_shape_base_impl.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Concatenate, ParamSpec, Protocol, SupportsIndex, TypeVar, overload, type_check_only
+from typing import Any, Concatenate, Protocol, SupportsIndex, overload, type_check_only
+from typing_extensions import ParamSpec, TypeVar
 
 import numpy as np
 from numpy._core.shape_base import vstack as row_stack

--- a/src/numpy-stubs/lib/_stride_tricks_impl.pyi
+++ b/src/numpy-stubs/lib/_stride_tricks_impl.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterable
-from typing import Any, SupportsIndex, TypeVar, overload
+from typing import Any, SupportsIndex, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import ArrayLike, NDArray, _ArrayLike, _Shape, _ShapeLike

--- a/src/numpy-stubs/lib/_twodim_base_impl.pyi
+++ b/src/numpy-stubs/lib/_twodim_base_impl.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Callable, Sequence
-from typing import Any, Literal as L, TypeAlias, TypeVar, overload
+from typing import Any, Literal as L, TypeAlias, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import (

--- a/src/numpy-stubs/lib/_type_check_impl.pyi
+++ b/src/numpy-stubs/lib/_type_check_impl.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Container, Iterable
-from typing import Any, Literal as L, TypeVar, overload
+from typing import Any, Literal as L, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import ArrayLike, NBitBase, NDArray, _64Bit, _ArrayLike, _ScalarLike_co, _SupportsDType

--- a/src/numpy-stubs/lib/_ufunclike_impl.pyi
+++ b/src/numpy-stubs/lib/_ufunclike_impl.pyi
@@ -1,4 +1,5 @@
-from typing import Any, TypeVar, overload
+from typing import Any, overload
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import NDArray, _ArrayLikeFloat_co, _ArrayLikeObject_co, _FloatLike_co

--- a/src/numpy-stubs/linalg/_linalg.pyi
+++ b/src/numpy-stubs/linalg/_linalg.pyi
@@ -6,9 +6,9 @@ from typing import (
     SupportsIndex,
     SupportsInt,
     TypeAlias,
-    TypeVar,
     overload,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy import vecdot  # noqa: ICN003

--- a/src/numpy-stubs/ma/core.pyi
+++ b/src/numpy-stubs/ma/core.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from collections.abc import Callable
-from typing import Any, TypeVar
-from typing_extensions import Self
+from typing import Any
+from typing_extensions import Self, TypeVar
 
 import numpy as np
 from numpy import amax, amin, angle, bool_, clip, expand_dims, indices, squeeze  # noqa: ICN003

--- a/src/numpy-stubs/ma/mrecords.pyi
+++ b/src/numpy-stubs/ma/mrecords.pyi
@@ -1,5 +1,6 @@
 from _typeshed import Incomplete
-from typing import Any, TypeVar
+from typing import Any
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/polynomial/_polybase.pyi
+++ b/src/numpy-stubs/polynomial/_polybase.pyi
@@ -8,14 +8,12 @@ from typing import (
     Final,
     Generic,
     Literal,
-    LiteralString,
-    Self,
     SupportsIndex,
     TypeAlias,
     TypeGuard,
     overload,
 )
-from typing_extensions import TypeVar
+from typing_extensions import LiteralString, Self, TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/src/numpy-stubs/polynomial/_polytypes.pyi
+++ b/src/numpy-stubs/polynomial/_polytypes.pyi
@@ -2,17 +2,15 @@ from collections.abc import Callable, Sequence
 from typing import (
     Any,
     Literal,
-    LiteralString,
     NoReturn,
     Protocol,
-    Self,
     SupportsIndex,
     SupportsInt,
     TypeAlias,
     overload,
     type_check_only,
 )
-from typing_extensions import TypeVar
+from typing_extensions import LiteralString, Self, TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/src/numpy-stubs/polynomial/chebyshev.pyi
+++ b/src/numpy-stubs/polynomial/chebyshev.pyi
@@ -4,9 +4,9 @@ from typing import (
     Concatenate,
     Final,
     Literal as L,
-    TypeVar,
     overload,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/src/numpy-stubs/polynomial/hermite.pyi
+++ b/src/numpy-stubs/polynomial/hermite.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Final, Literal as L, TypeVar
+from typing import Any, Final, Literal as L
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/polynomial/hermite_e.pyi
+++ b/src/numpy-stubs/polynomial/hermite_e.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Final, Literal as L, TypeVar
+from typing import Any, Final, Literal as L
+from typing_extensions import TypeVar
 
 import numpy as np
 

--- a/src/numpy-stubs/polynomial/polyutils.pyi
+++ b/src/numpy-stubs/polynomial/polyutils.pyi
@@ -5,9 +5,9 @@ from typing import (
     Literal,
     SupportsIndex,
     TypeAlias,
-    TypeVar,
     overload,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 import numpy.typing as npt

--- a/src/numpy-stubs/random/bit_generator.pyi
+++ b/src/numpy-stubs/random/bit_generator.pyi
@@ -6,11 +6,11 @@ from typing import (
     Literal,
     NamedTuple,
     TypeAlias,
-    TypeVar,
     TypedDict,
     overload,
     type_check_only,
 )
+from typing_extensions import TypeVar
 
 import numpy as np
 from numpy._typing import NDArray, _ArrayLikeInt_co, _DTypeLike, _ShapeLike, _UInt32Codes, _UInt64Codes

--- a/src/numpy-stubs/testing/_private/utils.pyi
+++ b/src/numpy-stubs/testing/_private/utils.pyi
@@ -14,14 +14,12 @@ from typing import (
     Final,
     Literal as L,
     NoReturn,
-    ParamSpec,
     SupportsIndex,
     TypeAlias,
-    TypeVar,
     overload,
     type_check_only,
 )
-from typing_extensions import Self
+from typing_extensions import ParamSpec, Self, TypeVar
 from unittest.case import SkipTest
 
 import numpy as np

--- a/src/numpy-stubs/version.pyi
+++ b/src/numpy-stubs/version.pyi
@@ -1,18 +1,10 @@
-from typing import Final, LiteralString
+from typing import Final
+from typing_extensions import LiteralString
 
-__all__ = (
-    "__version__",
-    "full_version",
-    "git_revision",
-    "release",
-    "short_version",
-    "version",
-)
+__version__: Final[LiteralString] = ...
+version: Final[LiteralString] = ...
+full_version: Final[LiteralString] = ...
+short_version: Final[LiteralString] = ...
 
-version: Final[LiteralString]
-__version__: Final[LiteralString]
-full_version: Final[LiteralString]
-
-git_revision: Final[LiteralString]
-release: Final[bool]
-short_version: Final[LiteralString]
+release: Final[bool] = ...
+git_revision: Final[LiteralString] = ...

--- a/tests/data/reveal/arithmetic.pyi
+++ b/tests/data/reveal/arithmetic.pyi
@@ -1,5 +1,6 @@
 import datetime as dt
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/array_api_info.pyi
+++ b/tests/data/reveal/array_api_info.pyi
@@ -1,4 +1,5 @@
-from typing import Literal, Never, assert_type
+from typing import Literal, Never
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/array_constructors.pyi
+++ b/tests/data/reveal/array_constructors.pyi
@@ -1,7 +1,8 @@
 import sys
 from collections import deque
 from pathlib import Path
-from typing import Any, TypeVar, assert_type
+from typing import Any
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/arraypad.pyi
+++ b/tests/data/reveal/arraypad.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
-from typing import Any, SupportsIndex, assert_type
+from typing import Any, SupportsIndex
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/arrayprint.pyi
+++ b/tests/data/reveal/arrayprint.pyi
@@ -1,6 +1,7 @@
 import contextlib
 from collections.abc import Callable
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/arraysetops.pyi
+++ b/tests/data/reveal/arraysetops.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/bitwise_ops.pyi
+++ b/tests/data/reveal/bitwise_ops.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, TypeAlias, assert_type
+from typing import Any, Literal as L, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/char.pyi
+++ b/tests/data/reveal/char.pyi
@@ -1,4 +1,5 @@
-from typing import TypeAlias, assert_type
+from typing import TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy._typing as np_t

--- a/tests/data/reveal/constants.pyi
+++ b/tests/data/reveal/constants.pyi
@@ -1,4 +1,5 @@
-from typing import Literal, assert_type
+from typing import Literal
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/datasource.pyi
+++ b/tests/data/reveal/datasource.pyi
@@ -1,5 +1,6 @@
 from pathlib import Path
-from typing import IO, Any, assert_type
+from typing import IO, Any
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/dtype.pyi
+++ b/tests/data/reveal/dtype.pyi
@@ -2,7 +2,8 @@ import ctypes as ct
 import datetime as dt
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Literal, TypeAlias, assert_type
+from typing import Any, Literal, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 from numpy.dtypes import StringDType

--- a/tests/data/reveal/einsumfunc.pyi
+++ b/tests/data/reveal/einsumfunc.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/emath.pyi
+++ b/tests/data/reveal/emath.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/fft.pyi
+++ b/tests/data/reveal/fft.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/flatiter.pyi
+++ b/tests/data/reveal/flatiter.pyi
@@ -1,4 +1,5 @@
-from typing import Literal, TypeAlias, assert_type
+from typing import Literal, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/fromnumeric.pyi
+++ b/tests/data/reveal/fromnumeric.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal as L, NoReturn, assert_type
+from typing import Any, Literal as L, NoReturn
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/getlimits.pyi
+++ b/tests/data/reveal/getlimits.pyi
@@ -1,4 +1,5 @@
-from typing import Any, LiteralString, assert_type
+from typing import Any
+from typing_extensions import LiteralString, assert_type
 
 import numpy as np
 from numpy._typing import _64Bit

--- a/tests/data/reveal/histograms.pyi
+++ b/tests/data/reveal/histograms.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/index_tricks.pyi
+++ b/tests/data/reveal/index_tricks.pyi
@@ -1,5 +1,6 @@
 from types import EllipsisType
-from typing import Any, Literal, assert_type
+from typing import Any, Literal
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/lib_function_base.pyi
+++ b/tests/data/reveal/lib_function_base.pyi
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from fractions import Fraction
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/lib_polynomial.pyi
+++ b/tests/data/reveal/lib_polynomial.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
-from typing import Any, NoReturn, assert_type
+from typing import Any, NoReturn
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/linalg.pyi
+++ b/tests/data/reveal/linalg.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/matrix.pyi
+++ b/tests/data/reveal/matrix.pyi
@@ -1,4 +1,5 @@
-from typing import Any, TypeAlias, assert_type
+from typing import Any, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/memmap.pyi
+++ b/tests/data/reveal/memmap.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/multiarray.pyi
+++ b/tests/data/reveal/multiarray.pyi
@@ -1,5 +1,6 @@
 import datetime as dt
-from typing import Any, Literal, TypeVar, assert_type
+from typing import Any, Literal
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/nbit_base_example.pyi
+++ b/tests/data/reveal/nbit_base_example.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar, assert_type
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/ndarray_assignability.pyi
+++ b/tests/data/reveal/ndarray_assignability.pyi
@@ -1,4 +1,5 @@
-from typing import Protocol, TypeAlias, TypeVar, assert_type
+from typing import Protocol, TypeAlias
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 from numpy._typing import _64Bit

--- a/tests/data/reveal/ndarray_conversion.pyi
+++ b/tests/data/reveal/ndarray_conversion.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/ndarray_misc.pyi
+++ b/tests/data/reveal/ndarray_misc.pyi
@@ -1,8 +1,8 @@
 import ctypes as ct
 import operator
 from types import ModuleType
-from typing import Any, Literal, assert_type
-from typing_extensions import CapsuleType
+from typing import Any, Literal
+from typing_extensions import CapsuleType, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/nditer.pyi
+++ b/tests/data/reveal/nditer.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/nested_sequence.pyi
+++ b/tests/data/reveal/nested_sequence.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 from numpy._typing import _NestedSequence
 

--- a/tests/data/reveal/npyio.pyi
+++ b/tests/data/reveal/npyio.pyi
@@ -2,7 +2,8 @@ import pathlib
 import re
 import zipfile
 from collections.abc import Mapping
-from typing import IO, Any, assert_type
+from typing import IO, Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/numeric.pyi
+++ b/tests/data/reveal/numeric.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/numerictypes.pyi
+++ b/tests/data/reveal/numerictypes.pyi
@@ -1,4 +1,5 @@
-from typing import Literal, assert_type
+from typing import Literal
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/polynomial_polybase.pyi
+++ b/tests/data/reveal/polynomial_polybase.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Literal as L, LiteralString, TypeAlias, TypeVar, assert_type
+from typing import Any, Literal as L, TypeAlias
+from typing_extensions import LiteralString, TypeVar, assert_type
 
 import numpy as np
 import numpy.polynomial as npp

--- a/tests/data/reveal/polynomial_polyutils.pyi
+++ b/tests/data/reveal/polynomial_polyutils.pyi
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
 from decimal import Decimal
 from fractions import Fraction
-from typing import Any, Literal as L, TypeAlias, assert_type
+from typing import Any, Literal as L, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.polynomial.polyutils as pu

--- a/tests/data/reveal/polynomial_series.pyi
+++ b/tests/data/reveal/polynomial_series.pyi
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
-from typing import Any, TypeAlias, assert_type
+from typing import Any, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.polynomial as npp

--- a/tests/data/reveal/random.pyi
+++ b/tests/data/reveal/random.pyi
@@ -1,6 +1,7 @@
 import threading
 from collections.abc import Sequence
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/rec.pyi
+++ b/tests/data/reveal/rec.pyi
@@ -1,5 +1,6 @@
 import io
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/scalars.pyi
+++ b/tests/data/reveal/scalars.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal, TypeAlias, assert_type
+from typing import Any, Literal, TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/shape.pyi
+++ b/tests/data/reveal/shape.pyi
@@ -1,4 +1,5 @@
-from typing import Any, NamedTuple, assert_type
+from typing import Any, NamedTuple
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/shape_base.pyi
+++ b/tests/data/reveal/shape_base.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/stride_tricks.pyi
+++ b/tests/data/reveal/stride_tricks.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/strings.pyi
+++ b/tests/data/reveal/strings.pyi
@@ -1,4 +1,5 @@
-from typing import TypeAlias, assert_type
+from typing import TypeAlias
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy._typing as np_t

--- a/tests/data/reveal/testing.pyi
+++ b/tests/data/reveal/testing.pyi
@@ -6,7 +6,8 @@ import unittest
 import warnings
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, TypeVar, assert_type
+from typing import Any
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/twodim_base.pyi
+++ b/tests/data/reveal/twodim_base.pyi
@@ -1,4 +1,5 @@
-from typing import Any, TypeVar, assert_type
+from typing import Any
+from typing_extensions import TypeVar, assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/type_check.pyi
+++ b/tests/data/reveal/type_check.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal, assert_type
+from typing import Any, Literal
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/ufunc_config.pyi
+++ b/tests/data/reveal/ufunc_config.pyi
@@ -1,6 +1,7 @@
 from _typeshed import SupportsWrite
 from collections.abc import Callable
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 

--- a/tests/data/reveal/ufunclike.pyi
+++ b/tests/data/reveal/ufunclike.pyi
@@ -1,4 +1,5 @@
-from typing import Any, assert_type
+from typing import Any
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt

--- a/tests/data/reveal/ufuncs.pyi
+++ b/tests/data/reveal/ufuncs.pyi
@@ -1,4 +1,5 @@
-from typing import Any, Literal, NoReturn, assert_type
+from typing import Any, Literal, NoReturn
+from typing_extensions import assert_type
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
this resolves 318 mypy errors