### PR TITLE
⚗️ hallucinate `numpy._numtype` into existence (for debugging)

### DIFF
--- a/src/numpy-stubs/_numtype.pyi
+++ b/src/numpy-stubs/_numtype.pyi
@@ -1,0 +1,3 @@
+from typing import Final
+
+TARGET: Final = "2.2.2"


### PR DESCRIPTION
... so that I can check whether mypy actually uses the `numtype` stubs, and not the `numpy` ones <sub>because I haven't been able to figure out how to do that yet...</sub>